### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,4 +1,6 @@
 name: Validate Renovate configuration
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/cilium/ariane/security/code-scanning/1](https://github.com/cilium/ariane/security/code-scanning/1)

The workflow in `.github/workflows/renovate-config-validator.yaml` should specify a `permissions` block to limit the GITHUB_TOKEN's rights. Since all steps are read-only (checkout code, run a validation container), the workflow does not require any write permissions. The proper fix is to add:
```yaml
permissions:
  contents: read
```
immediately after the workflow `name:` declaration, so it applies to the entire workflow. No additional imports, methods, or code definitions are needed; just one extra property in the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
