### PR TITLE
Treat queued dependency as in progress

### DIFF
--- a/internal/handlers/workflow_processor.go
+++ b/internal/handlers/workflow_processor.go
@@ -311,7 +311,7 @@ func (w *WorkflowProcessor) checkTriggerDependency(ctx context.Context, dependsO
 
 		// Conclusion must be success or skipped
 		if conclusion != "success" && conclusion != "skipped" {
-			inProgress = status == "in_progress"
+			inProgress = status == "in_progress" || status == "queued"
 			if inProgress {
 				w.logger.Debug().Msgf("Dependency workflow %s is still in progress (conclusion: %s)", workflow, conclusion)
 			} else {


### PR DESCRIPTION
If dependency workflow is queued, Ariane will react to trigger comment with confused emoji. This is misleading to users as they think they need to retrigger their trigger phrase.

This change causes Ariane to react with thumbs up even if dependency is not yet running, but is queued.