### PR TITLE
workflow run: filter PRs by branch if no PRs

### DIFF
--- a/internal/handlers/workflow_run.go
+++ b/internal/handlers/workflow_run.go
@@ -88,8 +88,36 @@ func (w *WorkflowRunHandler) Handle(ctx context.Context, eventType, deliveryID s
 			fullPullRequests = append(fullPullRequests, fullPR)
 		}
 		if len(fullPullRequests) == 0 {
-			logger.Debug().Msgf("No pull requests could be retrieved for this workflow run")
-			return nil
+			logger.Debug().Msg("Individual pull requests data could not be retrieved, trying to filter recent PRs by branch")
+			nextPage := 0
+		pages:
+			for {
+				possiblePRs, response, err := client.PullRequests.List(ctx, repositoryOwner, repositoryName, &github.PullRequestListOptions{
+					Direction: "desc",
+					ListOptions: github.ListOptions{
+						PerPage: 100,
+						Page:    nextPage,
+					},
+				})
+				if err != nil {
+					logger.Error().Err(err).Msg("Failed to list possible PRs")
+					return err
+				}
+				for _, pr := range possiblePRs {
+					if pr.GetHead().GetRef() == workflowRun.GetHeadBranch() {
+						fullPullRequests = append(fullPullRequests, pr)
+						break pages
+					}
+				}
+				if response.NextPage == 0 {
+					break pages
+				}
+				nextPage = response.NextPage
+			}
+			if len(fullPullRequests) == 0 {
+				logger.Debug().Msgf("No pull requests could be retrieved for this workflow run")
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
This change attempts to fix following scenario:

A contributor creates a PR from a fork. Committer runs CI on it.

This causes workflow run actor to be the committer, not the PR author.

This situation breaks our workflow run -> PR mapping logic because:
- PR retrieval by head requires us to use author along with branch. Author is nowhere in the workflow run event, only actor that triggered the workflow run.
- Individual PRs in `pull_requests` field of workflow_run are empty for events originating from forks.

As a last-ditch attempt to find the PR, this change retrieves lately created PRs and compares workflow run branch with each PR branch.