### PR TITLE
Don't skip dependencies of workflows that should run

### DIFF
--- a/internal/config/ariane_config.go
+++ b/internal/config/ariane_config.go
@@ -166,6 +166,11 @@ func (config *ArianeConfig) ShouldRunWorkflow(ctx context.Context, workflow stri
 		return false
 	}
 
+	// If the workflow is a dependency, it should run if any of it's dependant workflows should also run
+	if config.IsDependencyOfRunnableWorkflow(ctx, workflow, files) {
+		return true
+	}
+
 	// PathsRegex and PathsIgnoreRegex are both defined - this is UNSUPPORTED!!
 	// default to run the workflow no matter what
 	if workflowConfig.PathsRegex != "" && workflowConfig.PathsIgnoreRegex != "" {
@@ -287,4 +292,37 @@ func (config *ArianeConfig) Merge(other *ArianeConfig) *ArianeConfig {
 	}
 
 	return config
+}
+
+func (config *ArianeConfig) IsDependencyOfRunnableWorkflow(ctx context.Context, workflow string, files []*github.CommitFile) bool {
+
+	var triggersContainingWorkflow []string
+	for triggerName, trigger := range config.Triggers {
+		for _, w := range trigger.Workflows {
+			if w == workflow {
+				triggersContainingWorkflow = append(triggersContainingWorkflow, triggerName)
+			}
+		}
+	}
+
+	if len(triggersContainingWorkflow) == 0 {
+		return false //workflow is not in any trigger
+	}
+
+	for _, trigger := range config.Triggers {
+		for _, dependency := range trigger.DependsOn {
+			for _, triggerWithOGWorkflow := range triggersContainingWorkflow {
+				if dependency == triggerWithOGWorkflow {
+					// original workflow is a dependency of this trigger, check if any workflow from this trigger should run
+					for _, dependentWorkflow := range trigger.Workflows {
+						if config.ShouldRunWorkflow(ctx, dependentWorkflow, files) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/config/ariane_config_test.go
+++ b/internal/config/ariane_config_test.go
@@ -358,7 +358,8 @@ func Test_ShouldRunWorkflow(t *testing.T) {
 		Triggers: map[string]config.TriggerConfig{
 			"/foo":            {Workflows: []string{"foo.yaml"}},
 			"/bar":            {Workflows: []string{"bar.yaml"}},
-			"/enterprise-foo": {Workflows: []string{"enterprise-foo.yaml"}},
+			"/enterprise-foo": {Workflows: []string{"enterprise-foo.yaml"}, DependsOn: []string{"/dependency"}},
+			"/dependency":     {Workflows: []string{"dependency.yaml"}},
 		},
 		Workflows: map[string]config.WorkflowPathsRegexConfig{
 			"bar.yaml": {
@@ -372,6 +373,7 @@ func Test_ShouldRunWorkflow(t *testing.T) {
 				PathsRegex:       "(x|y)/",
 				PathsIgnoreRegex: "(test|Documentation|myproject)/",
 			},
+			"dependency.yaml": {},
 		},
 		AllowedTeams: []string{
 			"team1",
@@ -472,6 +474,24 @@ func Test_ShouldRunWorkflow(t *testing.T) {
 			FilenamesJson:  []byte(`[]`),
 			ExpectedResult: false,
 			ExpectedReason: "no changes exist, despite both paths-regex and paths-ignore-regex being defined - the workflow will not run",
+		},
+		{
+			Workflow:       "dependency.yaml",
+			FilenamesJson:  []byte(`[]`),
+			ExpectedResult: false,
+			ExpectedReason: "no changes exist",
+		},
+		{
+			Workflow:       "dependency.yaml",
+			FilenamesJson:  []byte(`[{"filename": ".github/workflows/foo.yaml"}]`),
+			ExpectedResult: false,
+			ExpectedReason: "no changes for either dependency or dependant workflow",
+		},
+		{
+			Workflow:       "dependency.yaml",
+			FilenamesJson:  []byte(`[{"filename": ".github/workflows/enterprise-foo.yaml"}]`),
+			ExpectedResult: true,
+			ExpectedReason: "Dependant workflow changed - dependency should be run",
 		},
 	}
 


### PR DESCRIPTION
If a workflow is a dependency of another workflow, it should not be skipped even if only this dependant workflow runs.

This change will help with image build workflows being skipped in workflow-only changes.